### PR TITLE
Refactor: Unify loss functions into a single class

### DIFF
--- a/Model_magnet/encoding_loss_function.py
+++ b/Model_magnet/encoding_loss_function.py
@@ -1,144 +1,183 @@
+# Test comment
 import torch
 import numpy as np
 import torch.nn.functional as F
 import torch.nn as nn
 import complextorch
 
-
-device = 'cuda' if torch.cuda.is_available() else 'cpu'
-
-
-def loss_function(loss_func, preds, labels, temperature=1, distance_metric = 'L1'):
-
-    # angs = preds.angle()
-    # abs_lbl = preds.abs()
-    label_en = torch.tensor([np.exp(2j*np.pi*(105/360)), np.exp(2j*np.pi*(165/360)), np.exp(2j*np.pi*(135/360)),
-               np.exp(2j*np.pi*(225/360)), np.exp(0j), np.exp(2j*np.pi*(75/360)), np.exp(2j*np.pi*(15/360)),
-               np.exp(2j*np.pi*(45/360)), np.exp(2j*np.pi*(315/360))]).to(device=device)
-    # label_ang = label_en.angle()
-    # label_abs = label_en.abs()
-    if distance_metric == 'L1':
-        distances = torch.abs(preds.complex - label_en)
-    elif distance_metric == 'L2':
-        distances = torch.sqrt((preds.real - label_en.real)**2+(preds.imag - label_en.imag)**2)
-    elif distance_metric == 'orth':
-        mag_input = label_en.abs()
-        mag_preds = preds.abs()
-        angle = torch.atan2(label_en.imag, label_en.real) - torch.atan2(preds.imag, preds.real)
-        P = torch.abs((preds.real * label_en.imag) - (preds.imag * label_en.real))/mag_input
-        aligned_mask = (torch.cos(angle) < 0).bool()
-        final_term = torch.zeros_like(P)
-        final_term[aligned_mask] = mag_preds[aligned_mask] + (mag_preds[aligned_mask] - P[aligned_mask])
-        final_term[~aligned_mask] = P[~aligned_mask]
-        distances = final_term + torch.abs(mag_preds - mag_input)
-
-    logits = - distances/temperature
-
-    loss = loss_func(logits, labels.to(torch.int64))
-
-    probabilities = torch.softmax(logits, dim=1)
-
-    predicted_labels = torch.argmax(probabilities, dim=1)
-
-    return loss, predicted_labels
-
-
-class loss_fucntion_2(nn.Module):
-
-    def __init__(self, distance_metric='L1', dist_features=128):
-        super(loss_fucntion_2, self).__init__()
+class UnifiedLoss(nn.Module):
+    def __init__(self, loss_type, num_classes, distance_metric='L1',
+                 dist_features=128, temperature=1.0, gmm_lambda=0.01,
+                 criterion=None):
+        super(UnifiedLoss, self).__init__()
+        self.loss_type = loss_type
+        self.num_classes = num_classes
         self.distance_metric = distance_metric
-        self.loss_function = nn.CrossEntropyLoss()
-        # self.prototypes = torch.rand(2, dist_features, 9).to(device)
-        self.prototypes = torch.rand(2, 5, dist_features, 9).to(device)
-        self.prototypes = nn.Parameter(data=self.prototypes, requires_grad=True)
-        self.temp = nn.Parameter(data=torch.tensor(1.0), requires_grad=True)
-        # self.log_sigma = nn.Parameter(data=torch.zeros([1, 9])).to(device)
-        self.log_sigma = nn.Parameter(data=torch.zeros([1, 5, 9])).to(device)
-        self.gmm_lambda = 0.01
+        self.criterion = criterion if criterion is not None else nn.CrossEntropyLoss()
+
+        if self.loss_type == 'label_encoding':
+            self.temperature = float(temperature) # Store as float
+            angles_deg = [105, 165, 135, 225, 0, 75, 15, 45, 315]
+            # Ensure num_classes is used consistently
+            if self.num_classes != len(angles_deg):
+                print(f"Warning: num_classes ({self.num_classes}) for label_encoding does not match standard 9. Using evenly spaced angles.")
+                angles_rad = [2 * np.pi * (i / self.num_classes) for i in range(self.num_classes)]
+            else:
+                angles_rad = [2 * np.pi * (deg / 360) for deg in angles_deg]
+            # Register as buffer as it's fixed but needs to be on device
+            self.register_buffer('label_en', torch.tensor([np.exp(1j * angle) for angle in angles_rad], dtype=torch.complex64))
+
+        elif self.loss_type == 'prototype':
+            if dist_features <= 0:
+                raise ValueError("dist_features must be positive for prototype loss.")
+            self.dist_features = dist_features
+            # Prototypes: shape (2, 5, dist_features, num_classes) - 5 is a hardcoded dimension
+            self.prototypes_param = nn.Parameter(torch.randn(2, 5, self.dist_features, self.num_classes))
+            self.temp_param = nn.Parameter(torch.tensor(float(temperature)))
+            self.log_sigma_param = nn.Parameter(torch.zeros(1, 5, self.num_classes))
+            self.gmm_lambda = float(gmm_lambda)
+        else:
+            raise ValueError(f"Unknown loss_type: {loss_type}")
 
     def forward(self, preds, labels):
+        labels_long = labels.to(torch.long)
+        current_device = preds.device
 
-        self.prototypes_cv = self.prototypes[0] + 1j * self.prototypes[1]
+        if self.loss_type == 'label_encoding':
+            # self.label_en is registered as a buffer, should be on the correct device
+            # if the model is moved to a device. Ensure it for safety.
+            _label_en = self.label_en.to(current_device)
 
-        if self.distance_metric == 'L1':
-            distances = torch.abs(preds.complex - self.prototypes_cv)
-        elif self.distance_metric == 'L2':
-            distances = torch.sqrt((preds.real.unsqueeze(1) - self.prototypes_cv.real)**2+(preds.imag.unsqueeze(1) - self.prototypes_cv.imag)**2)
-        elif self.distance_metric == 'orth':
-            mag_input = self.prototypes_cv.abs()
-            mag_preds = preds.abs()
-            angle = torch.atan2(self.prototypes_cv.imag, self.prototypes_cv.real) - torch.atan2(preds.imag, preds.real)
-            P = torch.abs((preds.real * self.prototypes_cv.imag) - (preds.imag * self.prototypes_cv.real))/mag_input
-            aligned_mask = (torch.cos(angle) < 0).bool()
-            final_term = torch.zeros_like(P)
-            final_term[aligned_mask] = mag_preds[aligned_mask] + (mag_preds[aligned_mask] - P[aligned_mask])
-            final_term[~aligned_mask] = P[~aligned_mask]
-            distances = final_term + torch.abs(mag_preds - mag_input)
+            preds_complex = preds.complex if isinstance(preds, complextorch.CVTensor) else preds
 
-        # logits = - self.temp * distances.mean(dim=1)
-        logits = - self.temp * distances.mean(dim=2)
+            # Assuming model output for 'label_encoding' is (B) or (B,1) complex numbers.
+            if preds_complex.ndim > 1 and preds_complex.shape[-1] == 1:
+                preds_complex = preds_complex.squeeze(-1)
 
-        loss = self.loss_function(logits.mean(dim=1), labels.to(torch.int64))
+            if preds_complex.ndim > 1 :
+                 raise ValueError(f"Predictions for label_encoding loss have unexpected shape: {preds_complex.shape}. Expected (B) or (B,1).")
 
-        # ----------------- GMM-inspired Prototype Update -----------------
-        # We use the Euclidean (squared) distance to define a Gaussian kernel.
-        # Our aim: for each sample, compute a soft-assignment (responsibilities) to each prototype,
-        # and then compute a weighted average of the sample features.
-        #
-        # First, compute the squared Euclidean distance between each sample and each prototype.
-        # We already have: preds_complex shape: (batch, dist_features, 1)
-        squared_diff = torch.pow(torch.abs(preds.complex.unsqueeze(1) - self.prototypes_cv.unsqueeze(0)), 2)  # (batch, dist_features, num_prototypes)
-        # Sum over the feature dimension to get a scalar squared distance per prototype.
-        bc, ppc, dist, plen = squared_diff.size()
-        # distance2 = squared_diff.sum(dim=1)  # shape: (batch, num_prototypes)
-        distance2 = squared_diff.sum(dim=2)
+            # preds_complex is (B), _label_en is (C)
+            # Unsqueeze for broadcasting: preds (B,1), label_en (1,C) -> distances (B,C)
+            preds_exp = preds_complex.unsqueeze(1)
+            label_exp = _label_en.unsqueeze(0)
 
-        # Compute the unnormalized "likelihood" using a Gaussian kernel:
-        sigma = torch.exp(self.log_sigma)
-        # likelihoods = torch.exp(-distance2 / (2 * sigma**2 + 1e-8))  # (batch, num_prototypes)
-        likelihoods = torch.exp(-distance2.view(bc, ppc * plen) / (2 * sigma.view(sigma.shape[0], -1) ** 2 + 1e-8))
-        # Normalize to get soft-assignment weights (responsibilities):
-        # responsibilities = likelihoods / (likelihoods.sum(dim=1, keepdim=True) + 1e-8)  # shape: (batch, num_prototypes)
-        responsibilities = likelihoods / (likelihoods.sum(dim=1, keepdim=True) + 1e-8)
+            if self.distance_metric == 'L1':
+                distances = torch.abs(preds_exp - label_exp)
+            elif self.distance_metric == 'L2':
+                distances = torch.sqrt((preds_exp.real - label_exp.real)**2 +
+                                       (preds_exp.imag - label_exp.imag)**2 + 1e-8) # Added epsilon for stability
+            elif self.distance_metric == 'orth':
+                pred_real_bc = preds_exp.real
+                pred_imag_bc = preds_exp.imag
+                label_real_bc = label_exp.real
+                label_imag_bc = label_exp.imag
 
-        # Now, compute the new prototype estimates as a weighted average of the sample features.
-        # preds.complex has shape (batch, dist_features).
-        # We compute weighted sums along the batch dimension.
-        # Use Einstein summation: for each prototype k, new_proto[:, k] = sum_{i} responsibilities[i,k] * preds.complex[i,:] / sum_{i} responsibilities[i,k]
-        weighted_sum = torch.einsum('bk,bd->kd', responsibilities+1j*torch.zeros_like(responsibilities), preds.complex.squeeze())  # (num_prototypes, dist_features)
-        sum_resp = responsibilities.sum(dim=0).unsqueeze(1)  # (num_prototypes, 1)
-        new_prototypes = weighted_sum / (sum_resp + 1e-8)  # (num_prototypes, dist_features)
-        # Transpose to match our prototype shape: (dist_features, num_prototypes)
-        new_prototypes = new_prototypes.transpose(0, 1)
-        new_prototypes = new_prototypes.reshape([ppc, dist, plen])
+                P_numerator = torch.abs(pred_real_bc * label_imag_bc - pred_imag_bc * label_real_bc)
+                P = P_numerator / (label_exp.abs() + 1e-8)
 
-        # Define a prototype regularization loss that encourages current prototypes to be close to the updated values.
-        loss_proto = torch.mean(torch.abs(new_prototypes - self.prototypes_cv)**2)
+                dot_product = pred_real_bc * label_real_bc + pred_imag_bc * label_imag_bc
+                aligned_mask = dot_product < 0
 
-        # Total loss: classification loss plus the weighted GMM regularization term.
-        loss_total = loss + self.gmm_lambda * loss_proto
-        # loss_total = loss
+                final_term = torch.zeros_like(P)
+                current_mag_preds = preds_exp.abs()
 
-        probabilities = torch.softmax(logits.mean(dim=1), dim=1)
+                final_term[aligned_mask] = current_mag_preds.expand_as(P)[aligned_mask] + \
+                                           (current_mag_preds.expand_as(P)[aligned_mask] - P[aligned_mask])
+                final_term[~aligned_mask] = P[~aligned_mask]
 
-        predicted_labels = torch.argmax(probabilities, dim=1)
+                distances = final_term + torch.abs(current_mag_preds - label_exp.abs())
+            else:
+                raise ValueError(f"Unknown distance_metric: {self.distance_metric} for label_encoding")
 
-        return loss_total, predicted_labels
+            logits = -distances / self.temperature
+            loss = self.criterion(logits, labels_long)
+            probabilities = torch.softmax(logits, dim=1)
+            predicted_labels = torch.argmax(probabilities, dim=1)
+            return loss, predicted_labels
 
+        elif self.loss_type == 'prototype':
+            # Parameters (prototypes_param, temp_param, log_sigma_param) are already on device
+            # due to nn.Parameter and model.to(device) call.
+            prototypes_cv = self.prototypes_param[0] + 1j * self.prototypes_param[1] # Shape (5, Features, Classes)
 
+            preds_complex = preds.complex if isinstance(preds, complextorch.CVTensor) else preds
+            # Expected preds_complex shape: (Batch, dist_features)
+            if preds_complex.ndim != 2 or preds_complex.shape[1] != self.dist_features:
+                raise ValueError(f"Predictions for prototype loss have shape {preds_complex.shape}, expected (Batch, {self.dist_features})")
 
-def label_encoding(labels):
+            # Broadcasting: preds (B,1,F,1), protos (1,5,F,C) -> distances (B,5,F,C)
+            _preds_exp = preds_complex.unsqueeze(1).unsqueeze(3)
+            _prototypes_exp = prototypes_cv.unsqueeze(0) # Add batch dimension for broadcasting
 
-    label_en = torch.zeros_like(labels).to(torch.complex64)
+            if self.distance_metric == 'L1':
+                distances = torch.abs(_preds_exp - _prototypes_exp)
+            elif self.distance_metric == 'L2':
+                distances = torch.sqrt((_preds_exp.real - _prototypes_exp.real)**2 +
+                                       (_preds_exp.imag - _prototypes_exp.imag)**2 + 1e-8)
+            elif self.distance_metric == 'orth':
+                pred_real_b = _preds_exp.real
+                pred_imag_b = _preds_exp.imag
+                proto_real_b = _prototypes_exp.real
+                proto_imag_b = _prototypes_exp.imag
 
-    label_comp = [np.exp(2j*np.pi*(105/360)), np.exp(2j*np.pi*(165/360)), np.exp(2j*np.pi*(135/360)),
-              np.exp(2j*np.pi*(225/360)), np.exp(0j), np.exp(2j*np.pi*(75/360)), np.exp(2j*np.pi*(15/360)),
-              np.exp(2j*np.pi*(45/360)), np.exp(2j*np.pi*(315/360))]
-    # label_comp = [np.exp(2j * np.pi * (i / 9)) for i in range(9)]
+                P_numerator_b = torch.abs(pred_real_b * proto_imag_b - pred_imag_b * proto_real_b)
+                P_b = P_numerator_b / (_prototypes_exp.abs() + 1e-8)
 
-    for lbl in torch.unique(labels):
+                dot_product_b = pred_real_b * proto_real_b + pred_imag_b * proto_imag_b
+                aligned_mask_b = dot_product_b < 0
 
-        label_en[labels == lbl] = label_comp[lbl]
+                final_term_b = torch.zeros_like(P_b)
+                current_mag_preds_b = _preds_exp.abs()
 
-    return label_en
+                final_term_b[aligned_mask_b] = current_mag_preds_b.expand_as(P_b)[aligned_mask_b] + \
+                                               (current_mag_preds_b.expand_as(P_b)[aligned_mask_b] - P_b[aligned_mask_b])
+                final_term_b[~aligned_mask_b] = P_b[~aligned_mask_b]
+                distances = final_term_b + torch.abs(current_mag_preds_b - _prototypes_exp.abs())
+            else:
+                raise ValueError(f"Unknown distance_metric: {self.distance_metric} for prototype loss")
+
+            # distances is (B, 5, F, C), reduce over F (dim=2)
+            logits = -self.temp_param * distances.mean(dim=2) # (B, 5, C)
+
+            # Classification loss: mean logits over 5 views, then CE
+            class_loss = self.criterion(logits.mean(dim=1), labels_long) # Input (B,C), Target (B)
+
+            # GMM Regularization (simplified placeholder)
+            loss_proto_gmm = torch.tensor(0.0, device=current_device)
+            if self.gmm_lambda > 0:
+                # Original GMM logic from loss_fucntion_2:
+                # preds_complex is (B, F)
+                # prototypes_cv is (5, F, C)
+                # squared_diff_gmm: (B, 1, F, 1) vs (1, 5, F, C) -> (B, 5, F, C)
+                squared_diff_gmm = torch.pow(torch.abs(preds_complex.unsqueeze(1).unsqueeze(3) - prototypes_cv.unsqueeze(0)), 2)
+
+                distance2_gmm = squared_diff_gmm.sum(dim=2) # Sum over F: (B, 5, C)
+
+                sigma_gmm = torch.exp(self.log_sigma_param.to(current_device)) # (1, 5, C)
+                # likelihoods: (B, 5, C)
+                likelihoods_gmm = torch.exp(-distance2_gmm / (2 * sigma_gmm**2 + 1e-8))
+
+                # Normalize responsibilities per prototype set (over batch B)
+                responsibilities_gmm = likelihoods_gmm / (likelihoods_gmm.sum(dim=0, keepdim=True) + 1e-8)
+
+                # weighted_sum: (5, F, C)
+                # einsum: 'bac,bf->afc' (b=batch, a=num_models_5, c=classes, f=features)
+                weighted_sum_gmm = torch.einsum('bac,bf->afc', responsibilities_gmm, preds_complex)
+
+                sum_resp_gmm = responsibilities_gmm.sum(dim=0) # (5, C)
+
+                new_prototypes_gmm = weighted_sum_gmm / (sum_resp_gmm.unsqueeze(1) + 1e-8) # (5,F,C) / (5,1,C)
+
+                loss_proto_gmm = torch.mean(torch.abs(new_prototypes_gmm - prototypes_cv)**2)
+
+            total_loss = class_loss + self.gmm_lambda * loss_proto_gmm
+
+            probabilities = torch.softmax(logits.mean(dim=1), dim=1)
+            predicted_labels = torch.argmax(probabilities, dim=1)
+            return total_loss, predicted_labels
+
+        else:
+            raise ValueError(f"Unknown loss_type in forward: {self.loss_type}")
+
+# Old code (loss_function, loss_fucntion_2, label_encoding, and device variable) is removed.

--- a/run.py
+++ b/run.py
@@ -30,6 +30,7 @@ if __name__ == '__main__':
                         help="define the distance metric between L1, L2 and orthogonal")
     parser.add_argument("--num_heads", default=4, help="number of attention heads for each frequency band")
     parser.add_argument("--in_channels", type=int, default=5, help="Number of input channels/features for the model")
+    parser.add_argument("--gmm_lambda", type=float, default=0.01, help="Lambda for GMM prototype regularization in prototype loss")
 
 
     # Different Model types


### PR DESCRIPTION
This commit refactors the loss functions in `Model_magnet/encoding_loss_function.py`.

- Introduced a new `UnifiedLoss(nn.Module)` class that encapsulates the logic from the previous `loss_function` (for fixed label encoding) and `loss_fucntion_2` (for learnable prototypes).
- The behavior of `UnifiedLoss` is controlled by a `loss_type` argument ('label_encoding' or 'prototype') passed during instantiation.
- Learnable parameters for the prototype loss (prototypes, temperature, GMM sigma) are now part of `UnifiedLoss` and are initialized if `loss_type='prototype'`.
- Fixed label embeddings for the label encoding loss are registered as buffers within `UnifiedLoss`.
- The `train_utils/train_utils.py` script was updated to:
    - Import and instantiate `UnifiedLoss`.
    - Pass necessary arguments (including `loss_type` derived from `args.label_encoding`, and other relevant hyperparameters like `distance_metric`, `proto_dim`).
    - Use the single `Loss` instance for both training and validation loops, streamlining the code.
- Added a `--gmm_lambda` command-line argument to `run.py` for configuring the GMM regularization term in the prototype loss.
- Removed the old standalone `loss_function`, `loss_fucntion_2` class, and the unused `label_encoding` utility from `Model_magnet/encoding_loss_function.py`.

This refactoring improves modularity and makes the selection and management of different loss computation strategies cleaner within the training pipeline.