### PR TITLE
Feat: Add L2 regularization and Early Stopping to combat overfitting

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,7 +81,8 @@ def main(args):
 
         optimizer = optim.Adam(
             list(model.parameters()) + list(Loss_fn.parameters()),
-            lr=args.learning_rate
+            lr=args.learning_rate,
+            weight_decay=args.l2_normalization # Add this line
         )
 
         writer = SummaryWriter(log_dir=f"runs/FCMagnet_zero_2/fold_{fold}")

--- a/run.py
+++ b/run.py
@@ -32,6 +32,10 @@ if __name__ == '__main__':
     parser.add_argument("--in_channels", type=int, default=5, help="Number of input channels/features for the model")
     parser.add_argument("--gmm_lambda", type=float, default=0.01, help="Lambda for GMM prototype regularization in prototype loss")
 
+    # Early stopping parameters
+    parser.add_argument("--early_stopping_patience", type=int, default=10, help="Number of epochs to wait for improvement before early stopping (0 to disable)")
+    parser.add_argument("--early_stopping_min_delta", type=float, default=0.001, help="Minimum change in monitored quantity to qualify as an improvement")
+    parser.add_argument("--early_stopping_monitor", type=str, default="f1_score", choices=["f1_score", "accuracy", "loss"], help="Metric to monitor for early stopping (f1_score, accuracy, or loss)")
 
     # Different Model types
     parser.add_argument("--FFT-or-not", action='store_false',


### PR DESCRIPTION
This commit introduces two key mechanisms to help prevent model overfitting:

1.  **L2 Regularization (Weight Decay):**
    *   Modified `main.py` to add the `weight_decay` parameter to the `optim.Adam` optimizer, utilizing the value from the existing `args.l2_normalization` command-line argument. This applies L2 regularization to all trainable parameters (model and UnifiedLoss parameters).

2.  **Early Stopping:**
    *   Added new command-line arguments to `run.py`:
        *   `--early_stopping_patience` (default: 10): Number of epochs to wait for improvement before stopping (0 to disable).
        *   `--early_stopping_min_delta` (default: 0.001): Minimum change to qualify as an improvement.
        *   `--early_stopping_monitor` (default: "f1_score", choices: ["f1_score", "accuracy", "loss"]): Metric to monitor.
    *   Modified the `train_valid` function in `train_utils/train_utils.py` to implement early stopping logic:
        *   Tracks the best validation score for the chosen metric (`args.early_stopping_monitor`).
        *   If the validation score does not improve by at least `args.early_stopping_min_delta` for `args.early_stopping_patience` consecutive epochs, training is halted.

These features provide tools to better control model complexity and training duration, aiming for improved generalization to unseen data.