### PR TITLE
feat: Add attention heatmap generation

### DIFF
--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+import numpy as np
+from utils.plots import save_attention_heatmaps
+
+def test_save_attention_heatmaps():
+    # 1. Setup
+    test_dir = 'test_heatmaps'
+    # os.makedirs(test_dir, exist_ok=True) # The function should create the dir
+
+    # Create dummy data
+    attention_arrays = [
+        np.random.rand(2, 4, 5), # batch 1: 2 items, 4 classes, 5 bands
+        np.random.rand(2, 4, 5)  # batch 2: 2 items, 4 classes, 5 bands
+    ]
+    epoch = 1
+    fold = 0
+
+    # 2. Execute
+    save_attention_heatmaps(attention_arrays, epoch, fold, base_dir=test_dir)
+
+    # 3. Assert
+    expected_dir = os.path.join(test_dir, f'fold_{fold}', f'epoch_{epoch}')
+    assert os.path.isdir(expected_dir)
+
+    expected_files = [
+        'batch_0_item_0.png',
+        'batch_0_item_1.png',
+        'batch_1_item_0.png',
+        'batch_1_item_1.png'
+    ]
+
+    for f in expected_files:
+        assert os.path.isfile(os.path.join(expected_dir, f))
+
+    # 4. Teardown
+    shutil.rmtree(test_dir)

--- a/utils/plots.py
+++ b/utils/plots.py
@@ -1,0 +1,40 @@
+import os
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+def save_attention_heatmaps(attention_arrays, epoch, fold, base_dir='attention_heatmaps'):
+    """
+    Saves heatmaps of attention arrays for a given epoch and fold.
+
+    Args:
+        attention_arrays (list): A list of numpy arrays, where each array is a batch of attention weights.
+                                 The shape of each array is (batch_size, num_classes, num_bands).
+        epoch (int): The current epoch number.
+        fold (int): The current fold number.
+        base_dir (str): The base directory to save the heatmaps in.
+    """
+    # Create the directory for the fold and epoch
+    save_dir = os.path.join(base_dir, f'fold_{fold}', f'epoch_{epoch}')
+    os.makedirs(save_dir, exist_ok=True)
+
+    # Iterate through each batch of attention arrays
+    batch_item_count = 0
+    for batch_idx, batch_attention in enumerate(attention_arrays):
+        # Iterate through each attention map in the batch
+        for item_idx in range(batch_attention.shape[0]):
+            attention_map = batch_attention[item_idx]  # Shape: (num_classes, num_bands)
+
+            plt.figure(figsize=(10, 8))
+            sns.heatmap(attention_map, cmap='viridis')
+            plt.title(f'Attention Heatmap - Fold {fold}, Epoch {epoch}, Batch {batch_idx}, Item {item_idx}')
+            plt.xlabel('Bands')
+            plt.ylabel('Classes')
+
+            # Save the figure
+            save_path = os.path.join(save_dir, f'batch_{batch_idx}_item_{item_idx}.png')
+            plt.savefig(save_path)
+            plt.close()
+            batch_item_count +=1
+
+    print(f"Saved {batch_item_count} attention heatmaps to {save_dir}")


### PR DESCRIPTION
This commit introduces a new feature to generate and save heatmaps of attention arrays during training.

A new function `save_attention_heatmaps` is added to `utils/plots.py`. This function takes attention arrays, epoch, and fold number, and saves heatmaps in a structured directory: `attention_heatmaps/fold_{fold}/epoch_{epoch}`.

The training loop in `train_utils/train_utils.py` is modified to collect attention arrays during the validation phase. When a new best validation score is achieved, the `save_attention_heatmaps` function is called to save the heatmaps for that epoch.

A unit test is added in `tests/test_plots.py` to ensure the heatmap saving function works correctly.