### PR TITLE
feat: Add aggregated attention plotting

### DIFF
--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,34 +1,34 @@
 import os
 import shutil
 import numpy as np
-from utils.plots import save_attention_heatmaps
+from utils.plots import save_aggregated_attention_plots
 
-def test_save_attention_heatmaps():
+def test_save_aggregated_attention_plots():
     # 1. Setup
-    test_dir = 'test_heatmaps'
-    # os.makedirs(test_dir, exist_ok=True) # The function should create the dir
+    test_dir = 'test_aggregated_plots'
+    num_classes = 4
+    num_bands = 5
 
     # Create dummy data
     attention_arrays = [
-        np.random.rand(2, 4, 5), # batch 1: 2 items, 4 classes, 5 bands
-        np.random.rand(2, 4, 5)  # batch 2: 2 items, 4 classes, 5 bands
+        np.random.rand(2, num_classes, num_bands), # batch 1: 2 items
+        np.random.rand(2, num_classes, num_bands)  # batch 2: 2 items
     ]
+    # Total of 4 samples
+    labels = np.array([0, 1, 2, 3])
+
     epoch = 1
     fold = 0
 
     # 2. Execute
-    save_attention_heatmaps(attention_arrays, epoch, fold, base_dir=test_dir)
+    save_aggregated_attention_plots(attention_arrays, labels, epoch, fold, base_dir=test_dir)
 
     # 3. Assert
     expected_dir = os.path.join(test_dir, f'fold_{fold}', f'epoch_{epoch}')
     assert os.path.isdir(expected_dir)
 
-    expected_files = [
-        'batch_0_item_0.png',
-        'batch_0_item_1.png',
-        'batch_1_item_0.png',
-        'batch_1_item_1.png'
-    ]
+    # We expect one plot per class
+    expected_files = [f'aggregated_attention_class_{c}.png' for c in range(num_classes)]
 
     for f in expected_files:
         assert os.path.isfile(os.path.join(expected_dir, f))

--- a/train_utils/train_utils.py
+++ b/train_utils/train_utils.py
@@ -2,7 +2,7 @@ from torch.optim.lr_scheduler import CosineAnnealingLR
 from torch.utils.data import TensorDataset, DataLoader
 from tqdm import tqdm
 import time
-from utils.plots import save_attention_heatmaps
+from utils.plots import save_aggregated_attention_plots
 from utils.utils_loss import *
 from sklearn.metrics import confusion_matrix
 from scipy.signal import hilbert
@@ -217,7 +217,7 @@ def train_valid(model, optimizer, Loss, epochs, train_loader, valid_loader, writ
                     print(f"EarlyStopping: New best {args.early_stopping_monitor}: {best_val_metric:.4f}")
                     torch.save(model.state_dict(), os.path.join(args.save_dir, f'model_fold_{kwargs["fold"]}.pth'))
                     if args.multi_head_attention:
-                        save_attention_heatmaps(val_attentions, epoch, kwargs['fold'])
+                        save_aggregated_attention_plots(val_attentions, all_labels_tensor.cpu().numpy(), epoch, kwargs['fold'])
                 else:
                     epochs_no_improve += 1
                     print(f"EarlyStopping: No improvement in {args.early_stopping_monitor} for {epochs_no_improve} epoch(s). Best: {best_val_metric:.4f}, Current: {current_val_metric_for_early_stopping:.4f}")


### PR DESCRIPTION
This commit refactors the attention visualization feature to provide an aggregated view of band importance per class.

The `utils/plots.py` module is updated to replace the per-sample heatmap generation with a new function, `save_aggregated_attention_plots`. This function now averages the attention scores for each class across all samples in the validation set and generates a bar chart for each class, showing the average importance of each frequency band.

The training loop in `train_utils/train_utils.py` is updated to pass the validation labels to the new plotting function.

The unit test in `tests/test_plots.py` is updated to verify the new aggregated plotting functionality.